### PR TITLE
Update validations

### DIFF
--- a/g6/apiType.yml
+++ b/g6/apiType.yml
@@ -11,4 +11,10 @@ validations:
   -
     name: answer_required
     message: 'This question requires an answer.'
+  -
+    name: under_20_words
+    message: 'API type must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "API type can't be more than 200 characters."
 question: 'API type'

--- a/g6/codeLibraryLanguages.yml
+++ b/g6/codeLibraryLanguages.yml
@@ -7,4 +7,14 @@ hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples
 listItemName: 'code libraries example'
 type: list
 addthing: 'Add another code library'
+validations:
+  -
+    name: under_10_words
+    message: 'Each code library must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer code libraries.'
+  -
+    name: under_character_limit
+    message: 'Each code library must be no more than 100 characters.'
 question: 'Languages your code libraries are written in'

--- a/g6/dataBackupRecovery.yml
+++ b/g6/dataBackupRecovery.yml
@@ -13,5 +13,5 @@ filterLabel: 'Backup, disaster recovery and resilience plan in place'
 validations:
   -
     name: answer_required
-    message: 'Please answer if plans for backup, disaster recovery and resilience are in place'
+    message: 'This question requires an answer.'
 question: 'Backup, disaster recovery and resilience plan in place'

--- a/g6/deprovisioningTime.yml
+++ b/g6/deprovisioningTime.yml
@@ -11,4 +11,10 @@ validations:
   -
     name: answer_required
     message: 'This question requires an answer.'
+  -
+    name: under_20_words
+    message: 'Deprovisioning time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Deprovisioning time can't be more than 200 characters."
 question: 'Service deprovisioning time'

--- a/g6/identityStandards.yml
+++ b/g6/identityStandards.yml
@@ -7,4 +7,14 @@ hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
 type: list
 addthing: 'Add another standard'
+validations:
+  -
+    name: under_10_words
+    message: 'Each identity standard must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer identity standards.'
+  -
+    name: under_character_limit
+    message: 'Each identity standard must be no more than 100 characters.'
 question: 'Identity standards your service uses'

--- a/g6/pricingDocumentURL.yml
+++ b/g6/pricingDocumentURL.yml
@@ -1,4 +1,3 @@
-question: 'Pricing document'
 depends:
   -
     "on": lot
@@ -22,3 +21,4 @@ validations:
   -
     name: file_can_be_saved
     message: 'Your document failed to upload. Please try again.'
+question: 'Pricing document'

--- a/g6/provisioningTime.yml
+++ b/g6/provisioningTime.yml
@@ -5,10 +5,16 @@ depends:
       - SaaS
       - PaaS
       - IaaS
-hint: 'How long does it take to get your service up and running? For example 1 to 5 hours, 2 to 3 days.'
+hint: 'How long does it take to get your service up and running? eg 1 to 5 hours or 2 to 3 days. (Maximum 20 words.)'
 type: text
 validations:
   -
     name: answer_required
     message: 'This question requires an answer.'
+  -
+    name: under_20_words
+    message: 'Provisioning time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Provisioning time can't be more than 200 characters."
 question: 'Service provisioning time'

--- a/g6/serviceAvailabilityPercentage.yml
+++ b/g6/serviceAvailabilityPercentage.yml
@@ -17,5 +17,5 @@ validations:
     message: 'This question requires an answer.'
   -
     name: not_a_number
-    message: 'Availability must be a number less than 100'
+    message: 'Availability must be a number less than 100.'
 question: 'Service availability'

--- a/g6/serviceBenefits.yml
+++ b/g6/serviceBenefits.yml
@@ -13,11 +13,14 @@ addthing: 'Add another business benefit'
 validations:
   -
     name: answer_required
-    message: 'This question requires an answer'
+    message: 'This question requires an answer.'
   -
-    name: items_under_10_words_each
-    message: 'Each benefit must be less than 10 words'
+    name: under_10_words
+    message: 'Each benefit must be no more than 10 words.'
   -
     name: under_10_items
-    message: 'You must have 10 or fewer benefits'
+    message: 'You must have 10 or fewer benefits.'
+  -
+    name: under_character_limit
+    message: 'Each benefit must be no more than 100 characters.'
 question: 'Service benefits'

--- a/g6/serviceFeatures.yml
+++ b/g6/serviceFeatures.yml
@@ -15,9 +15,12 @@ validations:
     name: answer_required
     message: 'This question requires an answer.'
   -
-    name: items_under_10_words_each
-    message: 'Each feature must be less than 10 words'
+    name: under_10_words
+    message: 'Each feature must be no more than 10 words.'
   -
     name: under_10_items
-    message: 'You must have 10 or fewer features'
+    message: 'You must have 10 or fewer features.'
+  -
+    name: under_character_limit
+    message: 'Each feature must be no more than 100 characters.'
 question: 'Service features'

--- a/g6/serviceName.yml
+++ b/g6/serviceName.yml
@@ -13,6 +13,6 @@ validations:
     name: answer_required
     message: 'This question requires an answer.'
   -
-    name: under_100_characters
+    name: under_character_limit
     message: "Your service name can't be more than 100 characters."
 question: 'Service name'

--- a/g6/serviceSummary.yml
+++ b/g6/serviceSummary.yml
@@ -16,5 +16,8 @@ validations:
   -
     name: under_50_words
     message: 'Your description must not be more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description can't be more than 500 characters."
 question: 'Service summary'
 type: textbox_large

--- a/g6/supportAvailability.yml
+++ b/g6/supportAvailability.yml
@@ -12,4 +12,10 @@ validations:
   -
     name: answer_required
     message: 'This question requires an answer.'
+  -
+    name: under_20_words
+    message: 'Support availability must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Support availability can't be more than 200 characters."
 question: 'Support availability'

--- a/g6/supportResponseTime.yml
+++ b/g6/supportResponseTime.yml
@@ -12,4 +12,10 @@ validations:
   -
     name: answer_required
     message: 'This question requires an answer.'
+  -
+    name: under_20_words
+    message: 'Support response time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Support response time can't be more than 200 characters."
 question: 'Standard support response times'

--- a/g6/vendorCertifications.yml
+++ b/g6/vendorCertifications.yml
@@ -10,4 +10,14 @@ hint: 'Examples of certifications include VMware Certified Professional and Orac
 listItemName: 'certification example'
 type: list
 addthing: 'Add another certification'
+validations:
+    -
+      name: under_10_words
+      message: 'Each certification must be no more than 10 words.'
+    -
+      name: under_10_items
+      message: 'You must have 10 or fewer certifications.'
+    -
+      name: under_character_limit
+      message: 'Each certification must be no more than 100 characters.'
 question: 'Vendor certification(s)'


### PR DESCRIPTION
The JSON schema error messages for strings or lists that are too long don't include the length that was exceeded, so I've changed to a generic `under_character_limit` key, with individual questions in the content responsible for knowing what the limit was.

Some lists and string fields were missing validations in the content for max length and word count, so those have been added.

Also, I've ensured that all error messages have a full stop, as most of them did already but there were a few without.