### PR TITLE
Make price errors more specific

### DIFF
--- a/g6/priceString.yml
+++ b/g6/priceString.yml
@@ -16,10 +16,10 @@ validations:
     message: 'Pricing unit requires an answer. If none of the provided units apply, please choose ''Unit''.'
   -
     name: min_price_not_a_number
-    message: 'Prices must be numbers only, without units, eg 99.95'
+    message: 'Minimum price must be a number, without units, eg 99.95'
   -
     name: max_price_not_a_number
-    message: 'Prices must be numbers only, without units, eg 99.95'
+    message: 'Maximum price must be a number, without units, eg 99.95'
   -
     name: max_less_than_min
     message: 'Minimum price must be less than maximum price'


### PR DESCRIPTION
Make the messages for min or max prices not being numbers identify the
field that is in error.