### PR TITLE
Make t&c question the same style as other document questions

### DIFF
--- a/g6/termsAndConditionsDocumentURL.yml
+++ b/g6/termsAndConditionsDocumentURL.yml
@@ -1,4 +1,4 @@
-question: 'Please upload your terms and conditions document'
+question: 'Terms and conditions document'
 depends:
   -
     "on": lot


### PR DESCRIPTION
Currently the question for T&C document is a different style from other document upload questions - i.e:
![screen shot 2015-08-06 at 15 17 47](https://cloud.githubusercontent.com/assets/6525554/9113800/6cef8354-3c4e-11e5-85bb-331bd56f1f31.png)

This should make things look better.