### PR TITLE
Add validation messages for G7 declaration

### DIFF
--- a/g7_declaration/SQ1-1a.yml
+++ b/g7_declaration/SQ1-1a.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: under_character_limit
-    message: "This field must be a maximum of 255 characters."
+    message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1a.yml
+++ b/g7_declaration/SQ1-1a.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: under_character_limit
-    message: "This field must be a maximum of 5000 characters."
+    message: "Maximum 5000 characters."

--- a/g7_declaration/SQ1-1a.yml
+++ b/g7_declaration/SQ1-1a.yml
@@ -1,3 +1,7 @@
 question: What is the full name of the organisation applying to the G-Cloud 7 framework?
 hint: For a group of economic operators, this will be the name of the lead organisation. If you're submitting a response on behalf of another organisation, include their company name, not yours.
 type: text
+validations:
+  -
+    name: under_character_limit
+    message: "This field must be a maximum of 255 characters."

--- a/g7_declaration/SQ1-1cii.yml
+++ b/g7_declaration/SQ1-1cii.yml
@@ -1,2 +1,9 @@
 question: If you answered 'other' to question 19, please describe your trading status.
 type: text
+validations:
+  -
+    name: answer_required
+    message: "This question requires an answer because you answered 'other' to question 12"
+  -
+    name: under_character_limit
+    message: "This field must be a maximum of 255 characters."

--- a/g7_declaration/SQ1-1cii.yml
+++ b/g7_declaration/SQ1-1cii.yml
@@ -3,7 +3,7 @@ type: text
 validations:
   -
     name: answer_required
-    message: "You must answer this question because you answered 'other' to question 12"
+    message: "You must answer this question because you answered 'other' to question 19"
   -
     name: under_character_limit
     message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1cii.yml
+++ b/g7_declaration/SQ1-1cii.yml
@@ -6,4 +6,4 @@ validations:
     message: "You must answer this question because you answered 'other' to question 19"
   -
     name: under_character_limit
-    message: "This field must be a maximum of 5000 characters."
+    message: "Maximum 5000 characters."

--- a/g7_declaration/SQ1-1cii.yml
+++ b/g7_declaration/SQ1-1cii.yml
@@ -3,7 +3,7 @@ type: text
 validations:
   -
     name: answer_required
-    message: "This question requires an answer because you answered 'other' to question 12"
+    message: "You must answer this question because you answered 'other' to question 12"
   -
     name: under_character_limit
     message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1cii.yml
+++ b/g7_declaration/SQ1-1cii.yml
@@ -6,4 +6,4 @@ validations:
     message: "This question requires an answer because you answered 'other' to question 12"
   -
     name: under_character_limit
-    message: "This field must be a maximum of 255 characters."
+    message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1d-i.yml
+++ b/g7_declaration/SQ1-1d-i.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: under_character_limit
-    message: "This field must be a maximum of 255 characters."
+    message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1d-i.yml
+++ b/g7_declaration/SQ1-1d-i.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: under_character_limit
-    message: "This field must be a maximum of 5000 characters."
+    message: "Maximum 5000 characters."

--- a/g7_declaration/SQ1-1d-i.yml
+++ b/g7_declaration/SQ1-1d-i.yml
@@ -1,3 +1,7 @@
 question: When was your organisation first registered?
 hint: If you don't have a registered organisation, you don't need to answer this question.
 type: text
+validations:
+  -
+    name: under_character_limit
+    message: "This field must be a maximum of 255 characters."

--- a/g7_declaration/SQ1-1g.yml
+++ b/g7_declaration/SQ1-1g.yml
@@ -1,3 +1,7 @@
-question: What is the DUNS number for your organisation's head office?
+question: "What is the DUNS number for your organisation's head office?"
 hint: There are 9 digits in a DUNS number.
 type: text
+validations:
+  -
+    name: invalid_format
+    message: "There are either 9 digits in a DUNS number."

--- a/g7_declaration/SQ1-1g.yml
+++ b/g7_declaration/SQ1-1g.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: invalid_format
-    message: "There are either 9 digits in a DUNS number."
+    message: "You must enter a valid DUNS number."

--- a/g7_declaration/SQ1-1h.yml
+++ b/g7_declaration/SQ1-1h.yml
@@ -4,4 +4,4 @@ type: text
 validations:
   -
     name: invalid_format
-    message: "There are either 9 or 12 characters in a VAT number."
+    message: "You must enter a valid VAT number."

--- a/g7_declaration/SQ1-1h.yml
+++ b/g7_declaration/SQ1-1h.yml
@@ -1,3 +1,7 @@
-question: What is your organisation's registered VAT number? 
+question: "What is your organisation's registered VAT number?"
 hint: There are either 9 or 12 characters in a VAT number.
 type: text
+validations:
+  -
+    name: invalid_format
+    message: "There are either 9 or 12 characters in a VAT number."

--- a/g7_declaration/SQ1-1i-i.yml
+++ b/g7_declaration/SQ1-1i-i.yml
@@ -1,3 +1,7 @@
 question: If your business was not established in the UK, has it been registered with the appropriate professional or trade register(s) in the EU member state where it's established?
 hint: Check that your organisation complies with [Schedule 5, Regulation 58(5) of the Public Contracts Regulations 2015](http://www.legislation.gov.uk/uksi/2015/102/regulation/58/made). 
 type: boolean
+validations:
+  -
+    name: answer_required
+    message: "You must answer this question because you answered no to question 26"

--- a/g7_declaration/SQ1-1i-ii.yml
+++ b/g7_declaration/SQ1-1i-ii.yml
@@ -1,2 +1,9 @@
 question: "If you answered 'yes' to question 27, please provide details including your organisation's registration number."
 type: text
+validations:
+  -
+    name: answer_required
+    message: "This question requires an answer because you answered yes to question 20"
+  -
+    name: under_character_limit
+    message: "This field must be a maximum of 4096 characters."

--- a/g7_declaration/SQ1-1i-ii.yml
+++ b/g7_declaration/SQ1-1i-ii.yml
@@ -3,7 +3,7 @@ type: text
 validations:
   -
     name: answer_required
-    message: "You must answer this question because you answered yes to question 20"
+    message: "You must answer this question because you answered yes to question 27"
   -
     name: under_character_limit
     message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1i-ii.yml
+++ b/g7_declaration/SQ1-1i-ii.yml
@@ -6,4 +6,4 @@ validations:
     message: "This question requires an answer because you answered yes to question 20"
   -
     name: under_character_limit
-    message: "This field must be a maximum of 4096 characters."
+    message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1i-ii.yml
+++ b/g7_declaration/SQ1-1i-ii.yml
@@ -3,7 +3,7 @@ type: text
 validations:
   -
     name: answer_required
-    message: "This question requires an answer because you answered yes to question 20"
+    message: "You must answer this question because you answered yes to question 20"
   -
     name: under_character_limit
     message: "This field must be a maximum of 5000 characters."

--- a/g7_declaration/SQ1-1i-ii.yml
+++ b/g7_declaration/SQ1-1i-ii.yml
@@ -6,4 +6,4 @@ validations:
     message: "You must answer this question because you answered yes to question 27"
   -
     name: under_character_limit
-    message: "This field must be a maximum of 5000 characters."
+    message: "Maximum 5000 characters."

--- a/g7_declaration/SQ1-1j-i.yml
+++ b/g7_declaration/SQ1-1j-i.yml
@@ -6,4 +6,7 @@ options:
     label: licensed
   -
     label: a member of a relevant organisation
-
+validations:
+  -
+    name: answer_required
+    message: "You must answer this question because you answered no to question 26"

--- a/g7_declaration/SQ1-1j-ii.yml
+++ b/g7_declaration/SQ1-1j-ii.yml
@@ -3,4 +3,4 @@ type: text
 validations:
   -
     name: answer_required
-    message: "You must answer this question because you answered 'licenced' or 'a member of a relevant organisation' to question 22"
+    message: "You must answer this question because you answered 'licenced' or 'a member of a relevant organisation' to question 29"

--- a/g7_declaration/SQ1-1j-ii.yml
+++ b/g7_declaration/SQ1-1j-ii.yml
@@ -1,2 +1,6 @@
 question: If you answered 'licensed' or 'a member of a relevant organisation' in question 29, please give details of the state's requirements and confirm whether you've met them.
 type: text
+validations:
+  -
+    name: answer_required
+    message: "This question requires an answer because you answered 'licenced' or 'a member of a relevant organisation' to question 22"

--- a/g7_declaration/SQ1-1j-ii.yml
+++ b/g7_declaration/SQ1-1j-ii.yml
@@ -3,4 +3,4 @@ type: text
 validations:
   -
     name: answer_required
-    message: "This question requires an answer because you answered 'licenced' or 'a member of a relevant organisation' to question 22"
+    message: "You must answer this question because you answered 'licenced' or 'a member of a relevant organisation' to question 22"

--- a/g7_declaration/SQ3-1k.yml
+++ b/g7_declaration/SQ3-1k.yml
@@ -2,3 +2,7 @@ question: >
   If you responded yes to any of questions 39 to 51, please provide details of any
   mitigating factors that you think should be taken into consideration.
 type: textbox_large
+validations:
+  -
+    name: answer_required
+    message: "You must answer this question because you answered yes to one or more of questions 39 to 51."

--- a/g7_declaration/SQ4-1c.yml
+++ b/g7_declaration/SQ4-1c.yml
@@ -6,4 +6,4 @@ type: textbox_large
 validations:
   -
     name: answer_required
-    message: "This question is required because you answered yes to either question 54 or question 55."
+    message: "You must answer this question because you answered yes to either question 54 or question 55."

--- a/g7_declaration/SQ4-1c.yml
+++ b/g7_declaration/SQ4-1c.yml
@@ -1,9 +1,8 @@
 question: >
   If you responded 'yes' to either question 53 or question 54, please provide details of any mitigating factors that
-  you think should be taken into
-  consideration.
+  you think should be taken into consideration.
 type: textbox_large 
 validations:
   -
     name: answer_required
-    message: "You must answer this question because you answered yes to either question 54 or question 55."
+    message: "You must answer this question because you answered yes to either question 53 or question 54."

--- a/g7_declaration/SQ4-1c.yml
+++ b/g7_declaration/SQ4-1c.yml
@@ -3,3 +3,7 @@ question: >
   you think should be taken into
   consideration.
 type: textbox_large 
+validations:
+  -
+    name: answer_required
+    message: "This question is required because you answered yes to either question 54 or question 55."


### PR DESCRIPTION
This adds validation messages for the G7 supplier declaration form.

In addition to these error messages there is a default `answer_required` message for all non-optional fields set in the app. This is currently "This question is required".

cc/ @superroz 