### PR TITLE
Correct link URL to be local, not absolute

### DIFF
--- a/g7_declaration/PR5.yml
+++ b/g7_declaration/PR5.yml
@@ -1,2 +1,2 @@
-question: Have you read and understood [the guidance](https://www.digitalmarketplace.service.gov.uk/g-cloud/suppliers-guide) on how to apply to G-Cloud 7 using your supplier account on the Digital Marketplace?
+question: Have you read and understood [the guidance](/g-cloud/suppliers-guide) on how to apply to G-Cloud 7 using your supplier account on the Digital Marketplace?
 type: boolean


### PR DESCRIPTION
This was missed by the review of the [original pull request](https://github.com/alphagov/digitalmarketplace-ssp-content/pull/67).