### PR TITLE
Add email validation error messages

### DIFF
--- a/g7_declaration/SQ1-1o.yml
+++ b/g7_declaration/SQ1-1o.yml
@@ -1,3 +1,7 @@
 question: What is the contact email that should be included on the contract notice?
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.
 type: text
+validations:
+  -
+    name: invalid_format
+    message: "You must enter a valid email address."

--- a/g7_declaration/SQ1-2b.yml
+++ b/g7_declaration/SQ1-2b.yml
@@ -1,2 +1,6 @@
 question: What is the primary contact's email address?
 type: text
+validations:
+  -
+    name: invalid_format
+    message: "You must enter a valid email address."


### PR DESCRIPTION
I wasn't sure about "You must enter..." vs. "Please enter...", but all the other declaration question messages (e.g. VAT number, DUNS number) use "You must..." so I went with that for emails too.