### PR TITLE
Mark optional questions as optional

### DIFF
--- a/g6/apiType.yml
+++ b/g6/apiType.yml
@@ -18,3 +18,4 @@ validations:
     name: under_character_limit
     message: "API type can't be more than 200 characters."
 question: 'API type'
+optional: true

--- a/g6/codeLibraryLanguages.yml
+++ b/g6/codeLibraryLanguages.yml
@@ -18,3 +18,4 @@ validations:
     name: under_character_limit
     message: 'Each code library must be no more than 100 characters.'
 question: 'Languages your code libraries are written in'
+optional: true

--- a/g6/identityStandards.yml
+++ b/g6/identityStandards.yml
@@ -18,3 +18,4 @@ validations:
     name: under_character_limit
     message: 'Each identity standard must be no more than 100 characters.'
 question: 'Identity standards your service uses'
+optional: true


### PR DESCRIPTION
These are optional questions but were not marked as such, which will prevent users from being able to mark their service as complete unless they fill-in these optional questions.
