### PR TITLE
Content updates from clarification questions

### DIFF
--- a/g7_declaration/SQ1-1h.yml
+++ b/g7_declaration/SQ1-1h.yml
@@ -1,5 +1,5 @@
 question: "What is your organisation's registered VAT number?"
-hint: There are either 9 or 12 characters in a VAT number.
+hint: There are between 8 and 12 characters in a VAT number. If your organisation is not registered in Europe, enter N/A.
 type: text
 validations:
   -

--- a/g7_declaration/SQ1-1j-i.yml
+++ b/g7_declaration/SQ1-1j-i.yml
@@ -7,6 +7,8 @@ options:
     label: licensed
   -
     label: a member of a relevant organisation
+  -
+    label: none of the above    
 validations:
   -
     name: answer_required


### PR DESCRIPTION
- Changed hint text to VAT question. There's also a story in pivotal to strip out the validation here.
- Added a 'none of the above' option to the licensed/member of a relevant organisation question for Canadian companies.